### PR TITLE
Add demo for SoftwareReport Archive json generator

### DIFF
--- a/images/win/Windows2022-Archive.json
+++ b/images/win/Windows2022-Archive.json
@@ -1,0 +1,267 @@
+[
+    {
+      "Id": "OSVersion",
+      "Title": "OS Version: 10.0.20348 Build 1006",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "",
+        "",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Image Version",
+      "Title": "Image Version: ",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "",
+        "",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "WSL",
+      "Title": "Windows Subsystem for Linux [WSLv1]",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Enabled windows optional features",
+        "",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Bash",
+      "Title": "Bash 5.1.16(1)-release",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Go",
+      "Title": "Go 1.17.13",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Julia",
+      "Title": "Julia 1.8.2",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "LLVM",
+      "Title": "LLVM 14.0.6",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Node",
+      "Title": "Node 16.17.1",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Perl",
+      "Title": "Perl 5.32.1",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "PHP",
+      "Title": "PHP 8.1.11",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Python",
+      "Title": "Python 3.9.13",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Ruby",
+      "Title": "Ruby 3.0.4p208",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Kotlin",
+      "Title": "Kotlin 1.7.20",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Language and Runtime",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Choco",
+      "Title": "Chocolatey 1.1.0",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Conda",
+      "Title": "Miniconda 4.12.0 (pre-installed on the image but not added to PATH)",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Composer",
+      "Title": "Composer 2.4.2",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Helm",
+      "Title": "Helm 3.10.0",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "NPM",
+      "Title": "NPM 8.15.0",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Nuget",
+      "Title": "NuGet 6.3.0.131",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Pipx",
+      "Title": "Pipx 1.1.0",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Pip",
+      "Title": "pip 22.2.2 (python 3.9)",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Ruby",
+      "Title": "RubyGems 3.2.33",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Vcpkg",
+      "Title": "Vcpkg (build from master \\<083f103cf>)",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    },
+    {
+      "Id": "Yarn",
+      "Title": "Yarn 1.22.19",
+      "Headers": [
+        "Microsoft Windows Server 2022 Datacenter",
+        "Installed Software",
+        "Package Management",
+        "",
+        ""
+      ]
+    }
+  ]
+  

--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -1,6 +1,6 @@
 # Microsoft Windows Server 2022 Datacenter
 - OS Version: 10.0.20348 Build 1006
-- Image Version: 20221002.2
+- Image Version: 
 
 ## Enabled windows optional features
 - Windows Subsystem for Linux [WSLv1]
@@ -21,14 +21,14 @@
 ### Package Management
 - Chocolatey 1.1.0
 - Composer 2.4.2
-- Helm 3.9.4
+- Helm 3.10.0
 - Miniconda 4.12.0 (pre-installed on the image but not added to PATH)
 - NPM 8.15.0
 - NuGet 6.3.0.131
 - pip 22.2.2 (python 3.9)
 - Pipx 1.1.0
 - RubyGems 3.2.33
-- Vcpkg (build from master \<5f1441730>)
+- Vcpkg (build from master \<083f103cf>)
 - Yarn 1.22.19
 
 #### Environment variables
@@ -41,26 +41,26 @@
 - Ant 1.10.12
 - Gradle 7.5
 - Maven 3.8.6
-- sbt 1.7.1
+- sbt 1.7.2
 
 ### Tools
 - 7zip 22.01
 - aria2 1.36.0
-- azcopy 10.16.0
+- azcopy 10.16.1
 - Bazel 5.3.1
 - Bazelisk 1.13.2
 - Bicep 0.10.61
 - Cabal 3.8.1.0
 - CMake 3.24.2
 - CodeQL Action Bundle 2.11.0
+- Docker 20.10.18
 - Docker Compose v1 1.29.2
 - Docker Compose v2 2.11.2
-- Docker master-dockerproject-2022-03-26
 - Docker-wincred 0.7.0
 - ghc 9.4.2
 - Git 2.37.3.windows.1
 - Git LFS 3.2.0
-- ImageMagick 7.1.0-49
+- ImageMagick 7.1.0-50
 - InnoSetup 6.2.1
 - jq 1.6
 - Kind 0.16.0
@@ -71,7 +71,7 @@
 - NSIS v3.08
 - OpenSSL 1.1.1
 - Packer 1.8.2
-- Pulumi v3.40.2
+- Pulumi v3.42.0
 - R 4.2.1
 - Service Fabric SDK 9.0.1028.9590
 - Stack 2.9.1
@@ -85,12 +85,12 @@
 
 ### CLI Tools
 - Alibaba Cloud CLI 3.0.127
-- AWS CLI 2.8.0
-- AWS SAM CLI 1.58.0
+- AWS CLI 2.8.2
+- AWS SAM CLI 1.59.0
 - AWS Session Manager CLI 1.2.339.0
 - Azure CLI 2.40.0
 - Azure DevOps CLI extension 0.25.0
-- GitHub CLI 2.16.1
+- GitHub CLI 2.17.0
 - Hub CLI 2.14.2
 
 ### Rust Tools
@@ -101,18 +101,18 @@
 
 #### Packages
 - bindgen 0.60.1
-- cargo-audit 0.17.0
+- cargo-audit 0.17.2
 - cargo-outdated 0.11.1
 - cbindgen 0.24.3
 - Clippy 0.1.64
 - Rustfmt 1.5.1
 
 ### Browsers and webdrivers
-- Google Chrome 106.0.5249.91
+- Google Chrome 106.0.5249.103
 - Chrome Driver 106.0.5249.61
-- Microsoft Edge 105.0.1343.53
-- Microsoft Edge Driver 105.0.1343.53
-- Mozilla Firefox 105.0.1
+- Microsoft Edge 106.0.1370.42
+- Microsoft Edge Driver 106.0.1370.37
+- Mozilla Firefox 105.0.3
 - Gecko Driver 0.31.0
 - IE Driver 3.150.1.1
 - Selenium server 4.5.0
@@ -154,8 +154,8 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | Version | Architecture | Environment Variable |
 | ------- | ------------ | -------------------- |
 | 1.17.13 (Default) | x64          | GOROOT_1_17_X64      |
-| 1.18.6  | x64          | GOROOT_1_18_X64      |
-| 1.19.1  | x64          | GOROOT_1_19_X64      |
+| 1.18.7  | x64          | GOROOT_1_18_X64      |
+| 1.19.2  | x64          | GOROOT_1_19_X64      |
 
 #### Node
 | Version | Architecture |
@@ -567,13 +567,13 @@ All other versions are saved but not installed.
 #### Powershell Modules
 | Module             | Version          |
 | ------------------ | ---------------- |
-| AWSPowerShell      | 4.1.179          |
+| AWSPowerShell      | 4.1.184          |
 | DockerMsftProvider | 1.0.0.8          |
 | MarkdownPS         | 1.9              |
-| Microsoft.Graph    | 1.12.2           |
+| Microsoft.Graph    | 1.12.3           |
 | Pester             | 3.4.0<br>5.3.3   |
 | PowerShellGet      | 1.0.0.1<br>2.2.5 |
-| PSScriptAnalyzer   | 1.21.0           |
+| PSScriptAnalyzer   | 1.20.0<br>1.21.0 |
 | PSWindowsUpdate    | 2.2.0.3          |
 | SqlServer          | 21.1.18256       |
 | VSSetup            | 2.2.16           |

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -1,3 +1,7 @@
+####################  START OF DEMO SECTION  ####################
+
+using module ./SoftwareReport.Helpers.psm1
+
 $global:ErrorActionPreference = "Stop"
 $global:ProgressPreference = "SilentlyContinue"
 $ErrorView = "NormalView"
@@ -16,56 +20,59 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.WebServers.psm1") -Disabl
 Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -DisableNameChecking
 
 $markdown = ""
+$archive = [ArchiveItems]::New()
 
 $OSName = Get-OSName
-$markdown += New-MDHeader "$OSName" -Level 1
+$markdown += New-MDHeader $archive.SetHeader("$OSName", 1) -Level 1
 
 $OSVersion = Get-OSVersion
 $markdown += New-MDList -Style Unordered -Lines @(
-    "$OSVersion"
-    "Image Version: $env:IMAGE_VERSION"
+    $archive.Add("$OSVersion", "OSVersion")
+    $archive.Add("Image Version: $env:IMAGE_VERSION", "Image Version")
 )
 
 if ((Test-IsWin19) -or (Test-IsWin22))
 {
-    $markdown += New-MDHeader "Enabled windows optional features" -Level 2
+    $markdown += New-MDHeader $archive.SetHeader("Enabled windows optional features", 2) -Level 2
     $markdown += New-MDList -Style Unordered -Lines @(
-        "Windows Subsystem for Linux [WSLv1]"
+        $archive.Add("Windows Subsystem for Linux [WSLv1]", "WSL")
     )
 }
 
-$markdown += New-MDHeader "Installed Software" -Level 2
-$markdown += New-MDHeader "Language and Runtime" -Level 3
+$markdown += New-MDHeader $archive.SetHeader("Installed Software", 2) -Level 2
+$markdown += New-MDHeader $archive.SetHeader("Language and Runtime", 3) -Level 3
 $languageTools = @(
-    (Get-BashVersion),
-    (Get-GoVersion),
-    (Get-JuliaVersion),
-    (Get-LLVMVersion),
-    (Get-NodeVersion),
-    (Get-PerlVersion)
-    (Get-PHPVersion),
-    (Get-PythonVersion),
-    (Get-RubyVersion),
-    (Get-KotlinVersion)
+    $archive.Add((Get-BashVersion), "Bash")
+    $archive.Add((Get-GoVersion), "Go")
+    $archive.Add((Get-JuliaVersion), "Julia")
+    $archive.Add((Get-LLVMVersion), "LLVM")
+    $archive.Add((Get-NodeVersion), "Node")
+    $archive.Add((Get-PerlVersion), "Perl")
+    $archive.Add((Get-PHPVersion), "PHP")
+    $archive.Add((Get-PythonVersion), "Python")
+    $archive.Add((Get-RubyVersion), "Ruby")
+    $archive.Add((Get-KotlinVersion), "Kotlin")
 )
 $markdown += New-MDList -Style Unordered -Lines ($languageTools | Sort-Object)
 
+$markdown += New-MDHeader $archive.SetHeader("Package Management", 3) -Level 3
 $packageManagementList = @(
-    (Get-ChocoVersion),
-    (Get-CondaVersion),
-    (Get-ComposerVersion),
-    (Get-HelmVersion),
-    (Get-NPMVersion),
-    (Get-NugetVersion),
-    (Get-PipxVersion),
-    (Get-PipVersion),
-    (Get-RubyGemsVersion),
-    (Get-VcpkgVersion),
-    (Get-YarnVersion)
+    $archive.Add((Get-ChocoVersion), "Choco")
+    $archive.Add((Get-CondaVersion), "Conda")
+    $archive.Add((Get-ComposerVersion), "Composer")
+    $archive.Add((Get-HelmVersion), "Helm")
+    $archive.Add((Get-NPMVersion), "NPM")
+    $archive.Add((Get-NugetVersion), "Nuget")
+    $archive.Add((Get-PipxVersion), "Pipx")
+    $archive.Add((Get-PipVersion), "Pip")
+    $archive.Add((Get-RubyGemsVersion), "Ruby")
+    $archive.Add((Get-VcpkgVersion), "Vcpkg")
+    $archive.Add((Get-YarnVersion), "Yarn")
 )
 
-$markdown += New-MDHeader "Package Management" -Level 3
 $markdown += New-MDList -Style Unordered -Lines ($packageManagementList | Sort-Object)
+
+####################  END OF DEMO SECTION  ####################
 
 $markdown += New-MDHeader "Environment variables" -Level 4
 $markdown += Build-PackageManagementEnvironmentTable | New-MDTable
@@ -313,4 +320,5 @@ if ($cachedImages) {
 }
 
 Test-BlankElement -Markdown $markdown
-$markdown | Out-File -FilePath "C:\InstalledSoftware.md"
+$markdown | Out-File -FilePath "C:\InstalledSoftware2.md"
+$archive.ToJson() | Out-File -FilePath "C:\InstalledSoftwareArchive.json"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -1,3 +1,46 @@
+class ArchiveItem {
+    [string] $Id
+    [string] $Title
+    [string[]] $Headers
+}
+
+class ArchiveItems {
+    hidden [System.Collections.ArrayList] $items
+    hidden [string[]] $activeHeaders
+
+    ArchiveItems() {
+        $this.items = New-Object System.Collections.ArrayList
+        $this.activeHeaders = New-Object string[] 5
+    }
+
+    [string] Add($Title, $Id) {
+        $item = [ArchiveItem]::New()
+        $item.Id = $Id
+        $item.Title = $Title
+        $item.Headers = $this.activeHeaders | ForEach-Object { $_ } 
+        $this.items.Add($item) | Out-Null
+
+        return $Title
+    }
+
+    [string] SetHeader($Name, $Level) {
+        if ($Level -lt 1 -or $Level -gt $this.activeHeaders.Length) {
+            Write-Warning"[!] [ArchiveItems] Header level must be 1..5"
+            return $Name
+        }
+
+        $this.activeHeaders[$Level-1] = $Name
+        for ($i = $Level; $i -lt $this.activeHeaders.Length; $i++) {
+            $this.activeHeaders[$i] = ""
+        }
+        return $Name
+    }
+
+    [string] ToJson() {
+        return ConvertTo-Json $this.items -Depth 10
+    }
+}
+
 function Build-MarkdownElement
 {
     <#


### PR DESCRIPTION
## Description
#### Proposal to add possibility for additional generation of SoftwareReport output archive file in json format.

For the purposes of demonstration and testing, only the first few sections of the report were changed.

In the `Windows2022-Archive.json` file you can see an example of .json output, which was generated on a real Win image. For the purposes of this demonstration, only the minimal output for the first few sections of the report was generated.
